### PR TITLE
ksmbd-tools: add ksmbd.control util

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = lib mountd adduser addshare
+SUBDIRS = lib mountd adduser addshare control
 
 # other stuff
 EXTRA_DIST =			\

--- a/README
+++ b/README
@@ -45,7 +45,7 @@ steps:
 	- kill user space daemon
 		killall ksmbd.mountd
 	- kill kernel space daemon
-		echo hard > /sys/class/ksmbd-control/kill_server
+		sudo ksmbd.control -s
 	- restart user space daemon
 		ksmbd.mountd
 
@@ -57,9 +57,22 @@ steps:
 	- kill user space daemon
 		killall ksmbd.mountd
 	- kill kernel space daemon
-		echo hard > /sys/class/ksmbd-control/kill_server
+		sudo ksmbd.control -s
 	- unload ksmbd module
 		rmmod ksmbd
+
+
+_____________________
+Enable debug prints
+_____________________
+
+steps:
+	- Enable all component prints
+		sudo ksmbd.control -d "all"
+	- Enable one of components(smb, auth, vfs, oplock, ipc, conn, rdma)
+		sudo ksmbd.control -d "smb"
+	- Disable prints:
+		If you try the selected component once more, It is disabled without brackets.
 
 
 --------------------

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AC_CONFIG_FILES([
 	mountd/Makefile
 	adduser/Makefile
 	addshare/Makefile
+	control/Makefile
 ])
 
 AC_OUTPUT

--- a/control/Makefile.am
+++ b/control/Makefile.am
@@ -1,0 +1,7 @@
+AM_CFLAGS = -I$(top_srcdir)/include $(GLIB_CFLAGS) $(LIBNL_CFLAGS) -fno-common
+LIBS = $(GLIB_LIBS)
+ksmbd_control_LDADD = $(top_builddir)/lib/libksmbdtools.a
+
+sbin_PROGRAMS = ksmbd.control
+
+ksmbd_control_SOURCES = control.c

--- a/control/control.c
+++ b/control/control.c
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ *   Copyright (C) 2020 Samsung Electronics Co., Ltd.
+ *
+ *   linux-cifsd-devel@lists.sourceforge.net
+ */
+
+#include <getopt.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include "ksmbdtools.h"
+#include "version.h"
+
+static void usage(void)
+{
+	fprintf(stderr, "Usage: ksmbd.control\n");
+	fprintf(stderr, "\t-s | --shutdown\n");
+	fprintf(stderr, "\t-d | --debug=all or [smb, auth, etc...]\n");
+	fprintf(stderr, "\t-c | --cifsd-version\n");
+	fprintf(stderr, "\t-V | --version\n");
+
+	exit(EXIT_FAILURE);
+}
+
+static void show_version(void)
+{
+	printf("ksmbd-tools version : %s\n", KSMBD_TOOLS_VERSION);
+	exit(EXIT_FAILURE);
+}
+
+static int ksmbd_control_shutdown(void)
+{
+	int fd, ret;
+
+	fd = open("/sys/class/ksmbd-control/kill_server", O_WRONLY);
+	if (fd < 0) {
+		pr_err("open failed: %d\n", errno);
+		return fd;
+	}
+
+	ret = write(fd, "hard", 4);
+	close(fd);
+	return ret;
+}
+
+static int ksmbd_control_show_version(void)
+{
+	int fd, ret;
+	char ver[255] = {0};
+
+	fd = open("/sys/module/ksmbd/version", O_RDONLY);
+	if (fd < 0) {
+		pr_err("open failed: %d\n", errno);
+		return fd;
+	}
+
+	ret = read(fd, ver, 255);
+	close(fd);
+	if (ret != -1)
+		pr_info("cifsd version : %s\n", ver);
+	return ret;
+}
+
+static int ksmbd_control_debug(char *comp)
+{
+	int fd, ret;
+	char buf[255] = {0};
+
+	fd = open("/sys/class/ksmbd-control/debug", O_RDWR);
+	if (fd < 0) {
+		pr_err("open failed: %d\n", errno);
+		return fd;
+	}
+
+	ret = write(fd, comp, strlen(comp));
+	if (ret < 0)
+		goto out;
+	ret = read(fd, buf, 255);
+	if (ret < 0)
+		goto out;
+
+	pr_info("%s\n", buf);
+out:
+	close(fd);
+	return ret;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret = EXIT_FAILURE;
+	int c, cmd = 0;
+	char *section;
+
+	set_logger_app_name("ksmbd.control");
+
+	if (getuid() != 0) {
+		pr_err("Please try it as root.\n");
+		return ret;
+	}
+
+	opterr = 0;
+	while ((c = getopt(argc, argv, "sd:cVh")) != EOF)
+		switch (c) {
+		case 's':
+			ksmbd_control_shutdown();
+			break;
+		case 'd':
+			ret = ksmbd_control_debug(optarg);
+			break;
+		case 'c':
+			ret = ksmbd_control_show_version();
+			break;
+		case 'V':
+			show_version();
+			break;
+		case '?':
+		case 'h':
+		default:
+			usage();
+	}
+
+	if (argc < 2)
+		usage();
+
+	return ret;
+}


### PR DESCRIPTION
This patch add ksmbd.control util. It support the following functions.
 - Shutdown(kill) ksmbd daemon by "ksmbd.control -s" command.
 - Enable/Disable debug prints as per ksmbd component by "ksmbd.control
   -d "all" or -d "smb" command.
 - Show ksmbd version by "ksmbd.control -c" command.

Cc: Fredrik Ternerot <fredrikt@axis.com>
Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>