### PR TITLE
ksmbd-tools: fix possible double frees

### DIFF
--- a/mountd/rpc.c
+++ b/mountd/rpc.c
@@ -737,6 +737,7 @@ void rpc_destroy(void)
 	if (pipes_table) {
 		__clear_pipes_table();
 		g_hash_table_destroy(pipes_table);
+		pipes_table = NULL;
 	}
 	g_rw_lock_clear(&pipes_table_lock);
 	rpc_samr_destroy();

--- a/mountd/rpc_lsarpc.c
+++ b/mountd/rpc_lsarpc.c
@@ -603,7 +603,9 @@ int rpc_lsarpc_init(void)
 void rpc_lsarpc_destroy(void)
 {
 	g_free(domain_name);
-	if (ph_table)
+	if (ph_table) {
 		g_hash_table_destroy(ph_table);
+		ph_table = NULL;
+	}
 	g_rw_lock_clear(&ph_table_lock);
 }

--- a/mountd/rpc_samr.c
+++ b/mountd/rpc_samr.c
@@ -818,11 +818,15 @@ int rpc_samr_init(void)
 
 void rpc_samr_destroy(void)
 {
-	if (ch_table)
+	if (ch_table) {
 		g_hash_table_destroy(ch_table);
+		ch_table = NULL;
+	}
 	g_rw_lock_clear(&ch_table_lock);
 	num_domain_entries = 0;
 	g_free(domain_name);
-	if (domain_entries)
+	if (domain_entries) {
 		g_array_free(domain_entries, 1);
+		domain_entries = NULL;
+	}
 }

--- a/tools/management/session.c
+++ b/tools/management/session.c
@@ -221,6 +221,7 @@ void sm_destroy(void)
 	if (sessions_table) {
 		sm_clear_sessions();
 		g_hash_table_destroy(sessions_table);
+		sessions_table = NULL;
 	}
 	g_rw_lock_clear(&sessions_table_lock);
 }

--- a/tools/management/user.c
+++ b/tools/management/user.c
@@ -133,6 +133,7 @@ void usm_destroy(void)
 	if (users_table) {
 		usm_clear_users();
 		g_hash_table_destroy(users_table);
+		users_table = NULL;
 	}
 	g_rw_lock_clear(&users_table_lock);
 }


### PR DESCRIPTION
Make sure that functions such as g_hash_table_destroy() and g_array_free() can't be called on stale pointers.

Signed-off-by: Marios Makassikis <mmakassikis@freebox.fr>