### PR TITLE
Config parser fixes

### DIFF
--- a/tools/config_parser.c
+++ b/tools/config_parser.c
@@ -222,7 +222,7 @@ static int __mmap_parse_file(const char *fname, int (*callback)(char *data))
 
 	len = g_mapped_file_get_length(file);
 	while (len > 0) {
-		delim = strchr(contents, '\n');
+		delim = memchr(contents, '\n', len);
 		if (!delim)
 			delim = contents + len - 1;
 

--- a/tools/config_parser.c
+++ b/tools/config_parser.c
@@ -159,6 +159,13 @@ static int add_group_key_value(char *line)
 		return -ENOMEM;
 	}
 
+	if (!parser.current) {
+		pr_err("Key-value definition for `%s' is not in a group\n", key);
+		g_free(key);
+		g_free(value);
+		return -EINVAL;
+	}
+
 	if (g_hash_table_lookup(parser.current->kv, key)) {
 		pr_info("Multiple key-value definitions for `%s' in group `%s'\n",
 			key, parser.current->name);

--- a/tools/config_parser.c
+++ b/tools/config_parser.c
@@ -137,13 +137,15 @@ static int add_group_key_value(char *line)
 
 	value = key;
 	*key = 0x00;
-	key--;
-	value++;
 
-	while (is_ascii_space_tab(*key))
-		key--;
-	while (is_ascii_space_tab(*value))
-		value++;
+	do {
+		if (key == line)
+			return -EINVAL;
+	} while (is_ascii_space_tab(*--key));
+
+	do {
+		;
+	} while (is_ascii_space_tab(*++value));
 
 	if (is_a_comment(value))
 		return 0;


### PR DESCRIPTION
Two small fixes to to avoid crashing when dealing with invalid configuration files.