### PR TITLE
RPC parsing fixes

### DIFF
--- a/include/rpc_lsarpc.h
+++ b/include/rpc_lsarpc.h
@@ -11,6 +11,7 @@
 #include <smbacl.h>
 
 #define HANDLE_SIZE	20
+#define DOMAIN_STR_SIZE	257
 
 struct ksmbd_rpc_command;
 struct ksmbd_rpc_pipe;
@@ -23,7 +24,7 @@ struct policy_handle {
 struct lsarpc_names_info {
 	unsigned int index;
 	int type;
-	char domain_str[NAME_MAX];
+	char domain_str[DOMAIN_STR_SIZE];
 	struct smb_sid sid;
 	struct ksmbd_user *user;
 };

--- a/include/smbacl.h
+++ b/include/smbacl.h
@@ -73,7 +73,7 @@ struct smb_ace {
 
 void smb_init_domain_sid(struct smb_sid *sid);
 int smb_read_sid(struct ksmbd_dcerpc *dce, struct smb_sid *sid);
-void smb_write_sid(struct ksmbd_dcerpc *dce, const struct smb_sid *src);
+int smb_write_sid(struct ksmbd_dcerpc *dce, const struct smb_sid *src);
 void smb_copy_sid(struct smb_sid *dst, const struct smb_sid *src);
 int smb_compare_sids(const struct smb_sid *ctsid, const struct smb_sid *cwsid);
 int build_sec_desc(struct ksmbd_dcerpc *dce, __u32 *secdesclen, int rid);

--- a/include/smbacl.h
+++ b/include/smbacl.h
@@ -77,5 +77,5 @@ int smb_write_sid(struct ksmbd_dcerpc *dce, const struct smb_sid *src);
 void smb_copy_sid(struct smb_sid *dst, const struct smb_sid *src);
 int smb_compare_sids(const struct smb_sid *ctsid, const struct smb_sid *cwsid);
 int build_sec_desc(struct ksmbd_dcerpc *dce, __u32 *secdesclen, int rid);
-int set_domain_name(struct smb_sid *sid, char *domain, int *type);
+int set_domain_name(struct smb_sid *sid, char *domain, size_t domain_len, int *type);
 #endif /* __KSMBD_SMBACL_H__ */

--- a/mountd/ipc.c
+++ b/mountd/ipc.c
@@ -31,8 +31,10 @@ struct ksmbd_ipc_msg *ipc_msg_alloc(size_t sz)
 	struct ksmbd_ipc_msg *msg;
 	size_t msg_sz = sz + sizeof(struct ksmbd_ipc_msg) + 1;
 
-	if (msg_sz > KSMBD_IPC_MAX_MESSAGE_SIZE)
+	if (msg_sz > KSMBD_IPC_MAX_MESSAGE_SIZE) {
 		pr_err("IPC message is too large: %zu\n", msg_sz);
+		return NULL;
+	}
 
 	msg = g_try_malloc0(msg_sz);
 	if (msg)

--- a/mountd/rpc.c
+++ b/mountd/rpc.c
@@ -115,29 +115,6 @@ static void dcerpc_free(struct ksmbd_dcerpc *dce)
 	g_free(dce);
 }
 
-static struct ksmbd_dcerpc *dcerpc_alloc(unsigned int flags, int sz)
-{
-	struct ksmbd_dcerpc *dce;
-
-	dce = g_try_malloc0(sizeof(struct ksmbd_dcerpc));
-	if (!dce)
-		return NULL;
-
-	dce->payload = g_try_malloc0(sz);
-	if (!dce->payload) {
-		g_free(dce);
-		return NULL;
-	}
-
-	dce->payload_sz = sz;
-	dce->flags = flags;
-	dce->num_pointers = 1;
-
-	if (sz == KSMBD_DCERPC_MAX_PREFERRED_SIZE)
-		dce->flags &= ~KSMBD_DCERPC_FIXED_PAYLOAD_SZ;
-	return dce;
-}
-
 static struct ksmbd_dcerpc *dcerpc_ext_alloc(unsigned int flags,
 					     void *payload,
 					     int payload_sz)

--- a/mountd/rpc.c
+++ b/mountd/rpc.c
@@ -743,8 +743,10 @@ int rpc_init(void)
 	if (!pipes_table)
 		return -ENOMEM;
 	g_rw_lock_init(&pipes_table_lock);
-	rpc_samr_init();
-	rpc_lsarpc_init();
+	if (rpc_samr_init())
+		return -ENOMEM;
+	if (rpc_lsarpc_init())
+		return -ENOMEM;
 	return 0;
 }
 

--- a/mountd/rpc_lsarpc.c
+++ b/mountd/rpc_lsarpc.c
@@ -385,7 +385,7 @@ static int lsarpc_lookup_names3_invoke(struct ksmbd_rpc_pipe *pipe)
 			goto fail;
 		if (ndr_read_uniq_vstring_ptr(dce, &username))
 			goto fail;
-		if (strstr(STR_VAL(username), "\\")) {
+		if (STR_VAL(username) && strstr(STR_VAL(username), "\\")) {
 			strtok(STR_VAL(username), "\\");
 			name = strtok(NULL, "\\");
 		}

--- a/mountd/rpc_lsarpc.c
+++ b/mountd/rpc_lsarpc.c
@@ -708,7 +708,9 @@ int rpc_lsarpc_init(void)
 	 * ksmbd supports the standalone server and
 	 * uses the hostname as the domain name.
 	 */
-	gethostname(domain_string, NAME_MAX);
+	if (gethostname(domain_string, NAME_MAX))
+		return -ENOMEM;
+
 	domain_name = g_ascii_strup(domain_string, strlen(domain_string));
 	ph_table = g_hash_table_new(g_str_hash, g_str_equal);
 	if (!ph_table)

--- a/mountd/rpc_lsarpc.c
+++ b/mountd/rpc_lsarpc.c
@@ -304,7 +304,8 @@ static int lsarpc_lookup_sid2_invoke(struct ksmbd_rpc_pipe *pipe)
 			ni->user = usm_lookup_user(passwd->pw_name);
 
 		ni->index = i + 1;
-		if (set_domain_name(&ni->sid, ni->domain_str, &ni->type))
+		if (set_domain_name(&ni->sid, ni->domain_str,
+				    sizeof(ni->domain_str), &ni->type))
 			ni->index = -1;
 
 		pipe->entries = g_array_append_val(pipe->entries, ni);

--- a/mountd/rpc_samr.c
+++ b/mountd/rpc_samr.c
@@ -422,7 +422,9 @@ static int samr_query_user_info_return(struct ksmbd_rpc_pipe *pipe)
 	if (!ch)
 		return KSMBD_RPC_EBAD_FID;
 
-	gethostname(hostname, NAME_MAX);
+	if (gethostname(hostname, NAME_MAX))
+		return KSMBD_RPC_ENOMEM;
+
 	home_dir_len = 2 + strlen(hostname) + 1 + strlen(ch->user->name);
 
 	home_dir = g_try_malloc0(home_dir_len);
@@ -1035,7 +1037,9 @@ int rpc_samr_init(void)
 	 * ksmbd supports the standalone server and
 	 * uses the hostname as the domain name.
 	 */
-	gethostname(hostname, NAME_MAX);
+	if (gethostname(hostname, NAME_MAX))
+		return -ENOMEM;
+
 	domain_name = g_ascii_strup(hostname, strlen(hostname));
 	rpc_samr_add_domain_entry(domain_name);
 	rpc_samr_add_domain_entry("Builtin");

--- a/mountd/rpc_samr.c
+++ b/mountd/rpc_samr.c
@@ -1041,8 +1041,10 @@ int rpc_samr_init(void)
 		return -ENOMEM;
 
 	domain_name = g_ascii_strup(hostname, strlen(hostname));
-	rpc_samr_add_domain_entry(domain_name);
-	rpc_samr_add_domain_entry("Builtin");
+	if (rpc_samr_add_domain_entry(domain_name))
+		return -ENOMEM;
+	if (rpc_samr_add_domain_entry("Builtin"))
+		return -ENOMEM;
 	g_rw_lock_init(&ch_table_lock);
 	return 0;
 }

--- a/mountd/smbacl.c
+++ b/mountd/smbacl.c
@@ -37,6 +37,8 @@ int smb_read_sid(struct ksmbd_dcerpc *dce, struct smb_sid *sid)
 		return -EINVAL;
 	if (ndr_read_int8(dce, &sid->num_subauth))
 		return -EINVAL;
+	if (!sid->num_subauth || sid->num_subauth >= SID_MAX_SUB_AUTHORITIES)
+		return -EINVAL;
 	for (i = 0; i < NUM_AUTHS; ++i)
 		if (ndr_read_int8(dce, &sid->authority[i]))
 			return -EINVAL;

--- a/mountd/smbacl.c
+++ b/mountd/smbacl.c
@@ -9,6 +9,7 @@
 #include <smbacl.h>
 #include <tools.h>
 #include <glib.h>
+#include <rpc_lsarpc.h>
 
 static const struct smb_sid sid_domain = {1, 1, {0, 0, 0, 0, 0, 5},
 	{21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0} };
@@ -162,13 +163,13 @@ int set_domain_name(struct smb_sid *sid, char *domain, size_t domain_len,
 		    int *type)
 {
 	int ret = 0;
-	char domain_string[NAME_MAX] = {0};
+	char domain_string[DOMAIN_STR_SIZE] = {0};
 	g_autofree char *domain_name = NULL;
 
 	if (!smb_compare_sids(sid, &sid_domain) &&
 	    !memcmp(&sid->sub_auth[1], global_conf.gen_subauth,
 		    sizeof(__u32) * 3)) {
-		if (gethostname(domain_string, NAME_MAX))
+		if (gethostname(domain_string, DOMAIN_STR_SIZE))
 			return -ENOMEM;
 
 		domain_name = g_ascii_strup(domain_string, -1);

--- a/mountd/smbacl.c
+++ b/mountd/smbacl.c
@@ -168,7 +168,9 @@ int set_domain_name(struct smb_sid *sid, char *domain, int *type)
 	if (!smb_compare_sids(sid, &sid_domain) &&
 	    !memcmp(&sid->sub_auth[1], global_conf.gen_subauth,
 		    sizeof(__u32) * 3)) {
-		gethostname(domain_string, NAME_MAX);
+		if (gethostname(domain_string, NAME_MAX))
+			return -ENOMEM;
+
 		domain_name = g_ascii_strup(domain_string,
 				strlen(domain_string));
 		if (!domain_name)

--- a/mountd/worker.c
+++ b/mountd/worker.c
@@ -220,8 +220,11 @@ static int rpc_request(struct ksmbd_ipc_msg *msg)
 {
 	struct ksmbd_rpc_command *req;
 	struct ksmbd_rpc_command *resp;
-	struct ksmbd_ipc_msg *resp_msg;
+	struct ksmbd_ipc_msg *resp_msg = NULL;
 	int ret = -ENOTSUP;
+
+	if (msg->sz < sizeof(struct ksmbd_rpc_command))
+		goto out;
 
 	req = KSMBD_IPC_MSG_PAYLOAD(msg);
 	if (req->flags & KSMBD_RPC_METHOD_RETURN)


### PR DESCRIPTION
It is possible to crash ksmbd.mountd by sending invalid RPC requests.

This series adds some missing checks that fix crashes turned up by fuzzing the RPC code. The last commit is quite large as callers to ndr_write_* functions are modifed to check the return value and exit early. This is a mechanical change, but it's possible I missed something in the process.

