### PR TITLE
eliminate a use-after-free

### DIFF
--- a/tools/tools.c
+++ b/tools/tools.c
@@ -218,8 +218,6 @@ retry:
 			goto retry;
 		}
 
-		pr_err("Can't convert string: %s\n", err->message);
-		g_error_free(err);
 		return NULL;
 	}
 


### PR DESCRIPTION
Don't use err->message after g_error_free(err).
