### PR TITLE
ksmbd-tools: add support for durable handles

### DIFF
--- a/include/linux/ksmbd_server.h
+++ b/include/linux/ksmbd_server.h
@@ -29,6 +29,7 @@ struct ksmbd_heartbeat {
 #define KSMBD_GLOBAL_FLAG_SMB3_ENCRYPTION	(1 << 1)
 #define KSMBD_GLOBAL_FLAG_SMB3_MULTICHANNEL	(1 << 2)
 #define KSMBD_GLOBAL_FLAG_SMB3_ENCRYPTION_OFF	(1 << 3)
+#define KSMBD_GLOBAL_FLAG_DURABLE_HANDLES	(1 << 4)
 
 struct ksmbd_startup_request {
 	__u32	flags;

--- a/ksmbd.conf.5.in
+++ b/ksmbd.conf.5.in
@@ -76,6 +76,11 @@ Default: \fBdeadtime = 0\fR
 Octal bitmask that gets bitwise ANDed with DOS-to-UNIX-mapped permissions when creating a directory.
 
 Default: \fBdirectory mask = 0755\fR
+.TP
+\fBdurable handles\fR (G)
+Can grant SMB2 durable file handles on a share.
+
+Default: \fBdurable handles = no\fR
 \" .TP
 \" \fBfollow symlinks\fR (S)
 \" 

--- a/tools/config_parser.c
+++ b/tools/config_parser.c
@@ -518,6 +518,16 @@ static void process_global_conf_kv(char *k, char *v)
 				KSMBD_CONF_MAX_CONNECTIONS;
 		return;
 	}
+
+	if (!cp_key_cmp(k, "durable handles")) {
+		if (cp_get_group_kv_bool(v))
+			global_conf.flags |=
+				KSMBD_GLOBAL_FLAG_DURABLE_HANDLES;
+		else
+			global_conf.flags &=
+				~KSMBD_GLOBAL_FLAG_DURABLE_HANDLES;
+		return;
+	}
 }
 
 static void add_group_global_conf(void)


### PR DESCRIPTION
As durable handles is supported in ksmbd kernel server, Add durable handles parameter in ksmbd-tools. I would like to make it default disable till it is stable.